### PR TITLE
Change workshop id type to string

### DIFF
--- a/MobileWorkflowChartsPlugin/MWChartsPlugin/ChartStep/MWPieChartStep.swift
+++ b/MobileWorkflowChartsPlugin/MWChartsPlugin/ChartStep/MWPieChartStep.swift
@@ -42,10 +42,10 @@ public struct NetworkPieChartItemTask: CredentializedAsyncTask, URLAsyncTaskConv
 public class MWPieChartStep: ORKStep, PieChartStep {
     
     public let stepContext: StepContext
-    public let secondaryWorkflowIDs: [Int]
+    public let secondaryWorkflowIDs: [String]
     public let items: [PieChartItem]
     
-    init(identifier: String, stepContext: StepContext, secondaryWorkflowIDs: [Int], items: [PieChartItem]) {
+    init(identifier: String, stepContext: StepContext, secondaryWorkflowIDs: [String], items: [PieChartItem]) {
         self.stepContext = stepContext
         self.secondaryWorkflowIDs = secondaryWorkflowIDs
         self.items = items
@@ -76,7 +76,7 @@ extension MWPieChartStep: MobileWorkflowStep {
             return PieChartItem(label: label, value: value)
         }
         
-        let secondaryWorkflowIDs: [Int] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0["id"] as? Int }) ?? []
+        let secondaryWorkflowIDs: [String] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0.getString(key: "id") }) ?? []
         
         return MWPieChartStep(identifier: step.data.identifier, stepContext: step.context, secondaryWorkflowIDs: secondaryWorkflowIDs, items: items)
     }

--- a/MobileWorkflowChartsPlugin/MWChartsPlugin/ChartStep/MWPieChartStepViewController.swift
+++ b/MobileWorkflowChartsPlugin/MWChartsPlugin/ChartStep/MWPieChartStepViewController.swift
@@ -19,7 +19,7 @@ public class MWPieChartStepViewController: ORKStepViewController, HasSecondaryWo
     private var titleLabel: ORKTitleLabel!
     private(set) var pieChartView: PieChartView!
     
-    public var secondaryWorkflowIDs: [Int] {
+    public var secondaryWorkflowIDs: [String] {
         return self.pieChartStep.secondaryWorkflowIDs
     }
     

--- a/MobileWorkflowChartsPlugin/MWChartsPlugin/NetworkChartStep/MWNetworkPieChartStep.swift
+++ b/MobileWorkflowChartsPlugin/MWChartsPlugin/NetworkChartStep/MWNetworkPieChartStep.swift
@@ -15,13 +15,13 @@ public class MWNetworkPieChartStep: ORKStep, PieChartStep, RemoteContentStep, Sy
     public let stepContext: StepContext
     public let session: Session
     public let services: MobileWorkflowServices
-    public let secondaryWorkflowIDs: [Int]
+    public let secondaryWorkflowIDs: [String]
     public var contentURL: String?
     public let emptyText: String?
     public var resolvedURL: URL?
     public var items: [PieChartItem] = []
     
-    init(identifier: String, stepContext: StepContext, session: Session, services: MobileWorkflowServices, secondaryWorkflowIDs: [Int], url: String?, emptyText: String?) {
+    init(identifier: String, stepContext: StepContext, session: Session, services: MobileWorkflowServices, secondaryWorkflowIDs: [String], url: String?, emptyText: String?) {
         self.stepContext = stepContext
         self.session = session
         self.services = services
@@ -62,7 +62,7 @@ extension MWNetworkPieChartStep: MobileWorkflowStep {
         
         let url = step.data.content["url"] as? String
         let emptyText = services.localizationService.translate(step.data.content["emptyText"] as? String)
-        let secondaryWorkflowIDs: [Int] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0["id"] as? Int }) ?? []
+        let secondaryWorkflowIDs: [String] = (step.data.content["workflows"] as? [[String: Any]])?.compactMap({ $0.getString(key: "id") }) ?? []
         
         return MWNetworkPieChartStep(identifier: step.data.identifier, stepContext: step.context, session: step.session, services: services, secondaryWorkflowIDs: secondaryWorkflowIDs, url: url, emptyText: emptyText)
     }


### PR DESCRIPTION
With the latest change in the core to have workshop ID as a string, this plugin needs to be updated to match the new interfaces.