### PR TITLE
Chart dashboard tweaks

### DIFF
--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.0'
+    s.version               = '1.0.1'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
@@ -106,19 +106,19 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
         
         self.titleLabel.text = item.title
         
-        if let subtitle = item.subtitle {
+        if let text = item.text {
             self.subtitleLabel = UILabel()
             self.subtitleLabel?.translatesAutoresizingMaskIntoConstraints = false
             self.subtitleLabel?.numberOfLines = 0
             self.subtitleLabel?.adjustsFontForContentSizeCategory = true
             
-            self.subtitleLabel?.text = subtitle
+            self.subtitleLabel?.text = text
             self.subtitleLabel?.setContentCompressionResistancePriority(.required, for: .vertical)
             self.subtitleLabel?.setContentHuggingPriority(.required, for: .vertical)
             self.stackView.addArrangedSubview(self.subtitleLabel!)
         }
         
-        if item.chartType != .none {
+        if item.chartType != .statistic {
             self.graphContainerView = UIView()
             self.graphContainerView?.translatesAutoresizingMaskIntoConstraints = false
             self.stackView.addArrangedSubview(self.graphContainerView!)
@@ -128,12 +128,12 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Height is 0.6 times the width
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor, multiplier: 0.6).isActive = true
                 
-                let entries = item.values?.enumerated().map { BarChartDataEntry(x: Double($0.offset), y: $0.element) }
+                let entries = item.chartValues?.enumerated().map { BarChartDataEntry(x: Double($0.offset), y: $0.element) }
                 
                 let dataSet = BarChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
                 dataSet.drawIconsEnabled = false
-                dataSet.colors = [self.tintColor]
+                dataSet.colors = [theme.primaryTintColor]
                 
                 let chart = BarChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
@@ -157,7 +157,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Height is 0.6 times the width
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor, multiplier: 0.6).isActive = true
                 
-                let entries = item.values?.enumerated().map { ChartDataEntry(x: Double($0.offset), y: $0.element) }
+                let entries = item.chartValues?.enumerated().map { ChartDataEntry(x: Double($0.offset), y: $0.element) }
                 
                 let dataSet = LineChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
@@ -167,7 +167,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 dataSet.drawVerticalHighlightIndicatorEnabled = false
                 dataSet.drawHorizontalHighlightIndicatorEnabled = false
                 dataSet.lineWidth = 2
-                dataSet.colors = [self.tintColor]
+                dataSet.colors = [theme.primaryTintColor]
                 
                 let chart = LineChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
@@ -191,11 +191,11 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Square
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor).isActive = true
                 
-                let entries = item.values?.map { PieChartDataEntry(value: $0) }
+                let entries = item.chartValues?.map { PieChartDataEntry(value: $0) }
                 
                 let dataSet = PieChartDataSet(entries: entries, label: nil)
                 dataSet.drawValuesEnabled = false
-                dataSet.colors = tintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
+                dataSet.colors = theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
                 
                 let pieChartView = PieChartView()
                 pieChartView.translatesAutoresizingMaskIntoConstraints = false
@@ -208,7 +208,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 pieChartView.notifyDataSetChanged()
                 
                 self.graphContainerView?.addPinnedSubview(pieChartView)
-            case .none:
+            case .statistic:
                 break
             }
         }

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
@@ -10,7 +10,7 @@ import MobileWorkflowCore
 
 public struct DashboardStepItem: Codable {
     public enum ChartType: String, Codable {
-        case none
+        case statistic
         case pie
         case line
         case bar
@@ -18,18 +18,18 @@ public struct DashboardStepItem: Codable {
     
     let id: String
     let title: String
-    let subtitle: String?
+    let text: String?
     let footer: String?
     let chartType: ChartType
-    let values: [Double]?
+    let chartValues: [Double]?
     
-    public init(id: String, title: String, subtitle: String?, footer: String?, chartType: ChartType, values: [Double]?) {
+    public init(id: String, title: String, text: String?, footer: String?, chartType: ChartType, chartValues: [Double]?) {
         self.id = id
         self.title = title
-        self.subtitle = subtitle
+        self.text = text
         self.footer = footer
         self.chartType = chartType
-        self.values = values
+        self.chartValues = chartValues
     }
 }
 
@@ -37,10 +37,10 @@ extension DashboardStepItem: ValueProvider {
     public func fetchValue(for path: String) -> Any? {
         if path == CodingKeys.id.stringValue { return self.id }
         if path == CodingKeys.title.stringValue { return self.title }
-        if path == CodingKeys.subtitle.stringValue { return self.subtitle }
+        if path == CodingKeys.text.stringValue { return self.text }
         if path == CodingKeys.footer.stringValue { return self.footer }
         if path == CodingKeys.chartType.stringValue { return self.chartType }
-        if path == CodingKeys.values.stringValue { return self.values }
+        if path == CodingKeys.chartValues.stringValue { return self.chartValues }
         return nil
     }
     

--- a/MWChartsPlugin/MWChartsPlugin/NetworkDashboardStep/MWNetworkDashboardStep.swift
+++ b/MWChartsPlugin/MWChartsPlugin/NetworkDashboardStep/MWNetworkDashboardStep.swift
@@ -80,7 +80,7 @@ extension MWNetworkDashboardStep: BuildableStep {
         
         let url = stepInfo.data.content["url"] as? String
         let emptyText = services.localizationService.translate(stepInfo.data.content["emptyText"] as? String)
-        let numberOfColumns = (stepInfo.data.content["numberOfColumns"] as? String)?.toInt() ?? 2 // default to 2 columns
+        let numberOfColumns = (stepInfo.data.content["numberOfColumns"] as? String)?.toInt() ?? 1 // default to 1 column
 
         return MWNetworkDashboardStep(identifier: stepInfo.data.identifier, stepContext: stepInfo.context, session: stepInfo.session, services: services, url: url, emptyText: emptyText, numberOfColumns: numberOfColumns)
     }


### PR DESCRIPTION
- `none` chart type renamed to `statistic`
- `subtitle` property renamed to `text`
- `values` property renamed to `chartValues`
-  ensuring chart tint color comes from provided Theme
- supporting `numberOfColumns` property in static dashboard step