### PR TITLE
Updated dashboard resultKey

### DIFF
--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.1'
+    s.version               = '1.0.2'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepResult.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepResult.swift
@@ -10,7 +10,7 @@ import MobileWorkflowCore
 
 extension DashboardStepItem: SelectionItem {
     public var resultKey: String? {
-        return self.id
+        return self.title
     }
 }
 


### PR DESCRIPTION
**Task**

[[iOS] [Charts] Title on detail screen should use text not ID](https://3.basecamp.com/5245563/buckets/26145695/todos/4768046049/edit?replace=true)

**Summary**

In `viewControllerForStep(_step:previousStepViewController:)`, a `Selection` `resultKey` on previous step is used to populate the title for the next step, and dashboard step items are using `id`, which is not useful.

**Implementation**

- Added `selected.title` to plugin outputs in the builder, then updated the `resultKey` of `DashboardStepItem` from `id` to `title`.
- Also added a comment to `resultKey` property to remind that it's used to populate subsequent step's titles.