### PR TITLE
mandatoryCodingPaths implementations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     RubyInline (3.12.5)
       ZenTest (~> 4.3)
     ZenTest (4.12.1)
-    activesupport (6.1.4.6)
+    activesupport (6.1.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -19,10 +19,10 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.1.0)
-    cocoapods (1.11.2)
+    cocoapods (1.11.3)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.2)
+      cocoapods-core (= 1.11.3)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -37,7 +37,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 1.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.2)
+    cocoapods-core (1.11.3)
       activesupport (>= 5.0, < 7)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -48,7 +48,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.5.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-keys (2.2.1)
       dotenv
       osx_keychain
@@ -60,7 +60,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     dotenv (2.7.6)
     escape (0.0.4)
     ethon (0.15.0)
@@ -80,7 +80,7 @@ GEM
     netrc (0.11.0)
     osx_keychain (1.0.2)
       RubyInline (~> 3)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rexml (3.2.5)
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
@@ -105,4 +105,4 @@ DEPENDENCIES
   cocoapods-keys
 
 BUNDLED WITH
-   2.2.26
+   2.3.9

--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.4'
+    s.version               = '1.0.5'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts
@@ -15,9 +15,9 @@ Pod::Spec.new do |s|
 	s.default_subspecs      = 'Core'
 	
     s.subspec 'Core' do |cs|
-        cs.dependency            'MobileWorkflow', '~> 2.0.0'
-	    cs.dependency            'Charts', '~> 3.6.0'
-	    cs.dependency            'Colours', '~> 5.13.0'
+        cs.dependency            'MobileWorkflow', '~> 2.0.3'
+	cs.dependency            'Charts', '~> 3.6.0'
+	cs.dependency            'Colours', '~> 5.13.0'
         cs.source_files          = 'MWChartsPlugin/MWChartsPlugin/**/*.swift'
     end
 end

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
@@ -37,6 +37,11 @@ public class MWDashboardStep: MWStep, DashboardStep {
 }
 
 extension MWDashboardStep: BuildableStep {
+    
+    public static var mandatoryCodingPaths: [CodingKey] {
+        [["items": ["listItemId", "title", "chartType"]]]
+    }
+    
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
         
         let contentItems = stepInfo.data.content["items"] as? [[String: Any]] ?? []

--- a/MWChartsPlugin/MWChartsPlugin/NetworkDashboardStep/MWNetworkDashboardStep.swift
+++ b/MWChartsPlugin/MWChartsPlugin/NetworkDashboardStep/MWNetworkDashboardStep.swift
@@ -76,6 +76,10 @@ extension String {
 
 extension MWNetworkDashboardStep: BuildableStep {
     
+    public static var mandatoryCodingPaths: [CodingKey] {
+        ["url"] // see 'loadContent'
+    }
+    
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
         
         let url = stepInfo.data.content["url"] as? String

--- a/Podfile
+++ b/Podfile
@@ -12,8 +12,8 @@ project 'MWChartsPlugin/MWChartsPlugin.xcodeproj'
 
 abstract_target 'MWCharts' do
   pod 'MobileWorkflow'
-  pod 'Charts'
-  pod 'Colours'
+  pod 'Charts', '~> 3.6.0'
+  pod 'Colours', '~> 5.13.0'
 
   target 'MWCharts' do
     project 'MWCharts/MWCharts.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,13 +5,13 @@ PODS:
   - Colours (5.13.0):
     - Colours/ObjC (= 5.13.0)
   - Colours/ObjC (5.13.0)
-  - MobileWorkflow (2.0.1):
-    - MobileWorkflow/Core (= 2.0.1)
-  - MobileWorkflow/Core (2.0.1)
+  - MobileWorkflow (2.0.3):
+    - MobileWorkflow/Core (= 2.0.3)
+  - MobileWorkflow/Core (2.0.3)
 
 DEPENDENCIES:
-  - Charts
-  - Colours
+  - Charts (~> 3.6.0)
+  - Colours (~> 5.13.0)
   - MobileWorkflow
 
 SPEC REPOS:
@@ -24,8 +24,8 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   Colours: f24220c38f13deac88612667e9b4a7fb96b871d4
-  MobileWorkflow: a58d46cb9d98ab5486fa363aa33f2424a99dbb1d
+  MobileWorkflow: eb68eada630270ab88c501fc49647f15202b200f
 
-PODFILE CHECKSUM: 17ff9b6fdafd8eadb4a6176d58f7ab80bfda28fe
+PODFILE CHECKSUM: ba06e3f541ac089327d1661ad36a1f3cbbfb9083
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
### Task

[[iOS] [Plugins] Parsing errors should show property name](https://3.basecamp.com/5245563/buckets/26145695/todos/4637867015/edit?replace=true)

### Feature/Issue

Added implementations for `static public var mandatoryCodingPaths: [CodingKey]`.

### Implementation

Adding explicit implementations rather than relying on the fallback implementation in the core's `BuildableStep` protocol.