### PR TITLE
Support custom colors in charts

### DIFF
--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
@@ -133,8 +133,11 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 let dataSet = BarChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
                 dataSet.drawIconsEnabled = false
-                dataSet.colors = [theme.primaryTintColor]
-                
+                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
+                    dataSet.colors = colors
+                } else {
+                    dataSet.colors = [theme.primaryTintColor]
+                }
                 let chart = BarChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
                 chart.isUserInteractionEnabled = false
@@ -167,8 +170,11 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 dataSet.drawVerticalHighlightIndicatorEnabled = false
                 dataSet.drawHorizontalHighlightIndicatorEnabled = false
                 dataSet.lineWidth = 2
-                dataSet.colors = [theme.primaryTintColor]
-                
+                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
+                    dataSet.colors = colors
+                } else {
+                    dataSet.colors = [theme.primaryTintColor]
+                }
                 let chart = LineChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
                 chart.isUserInteractionEnabled = false
@@ -195,8 +201,11 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 
                 let dataSet = PieChartDataSet(entries: entries, label: nil)
                 dataSet.drawValuesEnabled = false
-                dataSet.colors = theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
-                
+                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
+                    dataSet.colors = colors
+                } else {
+                    dataSet.colors = theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
+                }
                 let pieChartView = PieChartView()
                 pieChartView.translatesAutoresizingMaskIntoConstraints = false
                 pieChartView.isUserInteractionEnabled = false

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
@@ -133,11 +133,8 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 let dataSet = BarChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
                 dataSet.drawIconsEnabled = false
-                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
-                    dataSet.colors = colors
-                } else {
-                    dataSet.colors = [theme.primaryTintColor]
-                }
+                dataSet.colors = item.colors ?? [theme.primaryTextColor]
+
                 let chart = BarChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
                 chart.isUserInteractionEnabled = false
@@ -170,11 +167,8 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 dataSet.drawVerticalHighlightIndicatorEnabled = false
                 dataSet.drawHorizontalHighlightIndicatorEnabled = false
                 dataSet.lineWidth = 2
-                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
-                    dataSet.colors = colors
-                } else {
-                    dataSet.colors = [theme.primaryTintColor]
-                }
+                dataSet.colors = item.colors ?? [theme.primaryTextColor]
+                
                 let chart = LineChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
                 chart.isUserInteractionEnabled = false
@@ -201,11 +195,8 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 
                 let dataSet = PieChartDataSet(entries: entries, label: nil)
                 dataSet.drawValuesEnabled = false
-                if let colors = item.chartColors?.compactMap({ UIColor(hex: $0) }), !colors.isEmpty {
-                    dataSet.colors = colors
-                } else {
-                    dataSet.colors = theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
-                }
+                dataSet.colors = item.colors ?? theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
+                
                 let pieChartView = PieChartView()
                 pieChartView.translatesAutoresizingMaskIntoConstraints = false
                 pieChartView.isUserInteractionEnabled = false

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
@@ -65,6 +65,12 @@ extension MWDashboardStep: BuildableStep {
                     $0.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
             }
+            var chartColorsDark: [String]?
+            if let valuesString = $0["chartColorsDark"] as? String {
+                chartColors = valuesString.components(separatedBy: ",").compactMap {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
             return DashboardStepItem(
                 id: id,
                 title: title,
@@ -72,7 +78,8 @@ extension MWDashboardStep: BuildableStep {
                 footer: services.localizationService.translate($0["footer"] as? String),
                 chartType: chartType,
                 chartValues: chartValues,
-                chartColors: chartColors
+                chartColors: chartColors,
+                chartColorsDark: chartColorsDark
             )
         }
         

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStep.swift
@@ -59,13 +59,20 @@ extension MWDashboardStep: BuildableStep {
                     $0.trimmingCharacters(in: .whitespacesAndNewlines).toDouble()
                 }
             }
+            var chartColors: [String]?
+            if let valuesString = $0["chartColors"] as? String {
+                chartColors = valuesString.components(separatedBy: ",").compactMap {
+                    $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
             return DashboardStepItem(
                 id: id,
                 title: title,
                 text: services.localizationService.translate($0["text"] as? String),
                 footer: services.localizationService.translate($0["footer"] as? String),
                 chartType: chartType,
-                chartValues: chartValues ?? []
+                chartValues: chartValues,
+                chartColors: chartColors
             )
         }
         

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStepViewController.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/MWDashboardStepViewController.swift
@@ -21,9 +21,10 @@ public class MWDashboardStepViewController: MWStepViewController {
         
         self.view.backgroundColor = self.step.theme.groupedBackgroundColor
     
-        self.collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
+        self.collectionView = UICollectionView(frame: self.view.bounds, collectionViewLayout: createLayout())
         self.collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.collectionView.alwaysBounceVertical = true
+        self.collectionView.isPrefetchingEnabled = false // if enabled, causes 'juddering' when scrolling to top
         self.view.addSubview(self.collectionView)
         self.collectionView.register(MWDashboardStepViewControllerCell.self)
         self.collectionView.delegate = self

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
@@ -23,8 +23,18 @@ public struct DashboardStepItem: Codable {
     let chartType: ChartType
     let chartValues: [Double]?
     let chartColors: [String]?
+    let chartColorsDark: [String]?
     
-    public init(id: String, title: String, text: String?, footer: String?, chartType: ChartType, chartValues: [Double]?, chartColors: [String]?) {
+    public init(
+        id: String,
+        title: String,
+        text: String?,
+        footer: String?,
+        chartType: ChartType,
+        chartValues: [Double]?,
+        chartColors: [String]?,
+        chartColorsDark: [String]?
+    ) {
         self.id = id
         self.title = title
         self.text = text
@@ -32,6 +42,20 @@ public struct DashboardStepItem: Codable {
         self.chartType = chartType
         self.chartValues = chartValues
         self.chartColors = chartColors
+        self.chartColorsDark = chartColorsDark
+    }
+    
+    var colors: [UIColor]? {
+        guard let chartColors = self.chartColors?.compactMap({ UIColor(hex: $0) }),
+              !chartColors.isEmpty else {
+            return nil // dark colors ignored if no light ones provided
+        }
+        if let chartColorsDark = self.chartColorsDark?.compactMap({ UIColor(hex: $0) }),
+           chartColorsDark.count == chartColors.count {
+            return zip(chartColors, chartColorsDark).map { UIColor(light: $0, dark: $1) }
+        } else {
+            return chartColors // dark colors ignored unless same number of light ones provided
+        }
     }
 }
 
@@ -44,6 +68,7 @@ extension DashboardStepItem: ValueProvider {
         if path == CodingKeys.chartType.stringValue { return self.chartType }
         if path == CodingKeys.chartValues.stringValue { return self.chartValues }
         if path == CodingKeys.chartColors.stringValue { return self.chartColors }
+        if path == CodingKeys.chartColorsDark.stringValue { return self.chartColorsDark }
         return nil
     }
     

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Model/DashboardStepItem.swift
@@ -22,14 +22,16 @@ public struct DashboardStepItem: Codable {
     let footer: String?
     let chartType: ChartType
     let chartValues: [Double]?
+    let chartColors: [String]?
     
-    public init(id: String, title: String, text: String?, footer: String?, chartType: ChartType, chartValues: [Double]?) {
+    public init(id: String, title: String, text: String?, footer: String?, chartType: ChartType, chartValues: [Double]?, chartColors: [String]?) {
         self.id = id
         self.title = title
         self.text = text
         self.footer = footer
         self.chartType = chartType
         self.chartValues = chartValues
+        self.chartColors = chartColors
     }
 }
 
@@ -41,6 +43,7 @@ extension DashboardStepItem: ValueProvider {
         if path == CodingKeys.footer.stringValue { return self.footer }
         if path == CodingKeys.chartType.stringValue { return self.chartType }
         if path == CodingKeys.chartValues.stringValue { return self.chartValues }
+        if path == CodingKeys.chartColors.stringValue { return self.chartColors }
         return nil
     }
     


### PR DESCRIPTION
### Task

[[iOS] [Charts] Improve alt-colours](https://3.basecamp.com/5245563/buckets/26145695/todos/4818764249/edit?replace=true)

### Summary

Allow greater customisation of chart colors by allowing them to be specified in app.json (static steps), or network response (network steps).

### Implementation

Added `chartColors` & `chartColorsDark` array to `DashboardStepItem`, and added this via app.json in the form of a comma separated list of hex colors (additive/non-breaking change to V4 of Charts Plugin).

`chartColorsDark` should be a complimentary list of the same length as `chartColors` otherwise it's ignored.