### PR TITLE
Corrected fallback color to tint rather than text

### DIFF
--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.3'
+    s.version               = '1.0.4'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
@@ -133,7 +133,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 let dataSet = BarChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
                 dataSet.drawIconsEnabled = false
-                dataSet.colors = item.colors ?? [theme.primaryTextColor]
+                dataSet.colors = item.colors ?? [theme.primaryTintColor]
 
                 let chart = BarChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false
@@ -167,7 +167,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 dataSet.drawVerticalHighlightIndicatorEnabled = false
                 dataSet.drawHorizontalHighlightIndicatorEnabled = false
                 dataSet.lineWidth = 2
-                dataSet.colors = item.colors ?? [theme.primaryTextColor]
+                dataSet.colors = item.colors ?? [theme.primaryTintColor]
                 
                 let chart = LineChartView()
                 chart.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Due to a typo the bar and line charts were falling back on using the `primaryTextColor` instead of `primaryTintColor`.