### PR TITLE
Fix compatibility with Xcode 14

### DIFF
--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
 	
     s.subspec 'Core' do |cs|
         cs.dependency            'MobileWorkflow', '~> 2.0.3'
-	cs.dependency            'Charts', '~> 4.0.3'
-	cs.dependency            'Colours', '~> 5.13.0'
+	    cs.dependency            'Charts', '~> 4.1.0'
+	    cs.dependency            'Colours', '~> 5.13.0'
         cs.source_files          = 'MWChartsPlugin/MWChartsPlugin/**/*.swift'
     end
 end

--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.7'
+    s.version               = '1.0.8'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 	
     s.subspec 'Core' do |cs|
         cs.dependency            'MobileWorkflow', '~> 2.0.3'
-	cs.dependency            'Charts', '~> 3.6.0'
+	cs.dependency            'Charts', '~> 4.0.3'
 	cs.dependency            'Colours', '~> 5.13.0'
         cs.source_files          = 'MWChartsPlugin/MWChartsPlugin/**/*.swift'
     end

--- a/MWChartsPlugin.podspec
+++ b/MWChartsPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWChartsPlugin'
-    s.version               = '1.0.8'
+    s.version               = '1.1.0'
     s.summary               = 'Chart plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     Chart plugin for MobileWorkflow on iOS, based on Charts by Daniel Gindi: https://github.com/danielgindi/Charts

--- a/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
+++ b/MWChartsPlugin/MWChartsPlugin/DashboardStep/Cell/MWDashboardStepViewControllerCell.swift
@@ -128,7 +128,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Height is 0.6 times the width
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor, multiplier: 0.6).isActive = true
                 
-                let entries = item.chartValues?.enumerated().map { BarChartDataEntry(x: Double($0.offset), y: $0.element) }
+                let entries = item.chartValues?.enumerated().map { BarChartDataEntry(x: Double($0.offset), y: $0.element) } ?? []
                 
                 let dataSet = BarChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
@@ -157,7 +157,7 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Height is 0.6 times the width
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor, multiplier: 0.6).isActive = true
                 
-                let entries = item.chartValues?.enumerated().map { ChartDataEntry(x: Double($0.offset), y: $0.element) }
+                let entries = item.chartValues?.enumerated().map { ChartDataEntry(x: Double($0.offset), y: $0.element) } ?? []
                 
                 let dataSet = LineChartDataSet(entries: entries)
                 dataSet.drawValuesEnabled = false
@@ -191,16 +191,16 @@ class MWDashboardStepViewControllerCell: UICollectionViewCell {
                 // Square
                 self.graphContainerView?.heightAnchor.constraint(equalTo: self.stackView.widthAnchor).isActive = true
                 
-                let entries = item.chartValues?.map { PieChartDataEntry(value: $0) }
+                let entries = item.chartValues?.map { PieChartDataEntry(value: $0) } ?? []
                 
-                let dataSet = PieChartDataSet(entries: entries, label: nil)
+                let dataSet = PieChartDataSet(entries: entries, label: "")
                 dataSet.drawValuesEnabled = false
                 dataSet.colors = item.colors ?? theme.primaryTintColor.colorScheme(ofType: .analagous) as? [UIColor] ?? dataSet.colors
                 
                 let pieChartView = PieChartView()
                 pieChartView.translatesAutoresizingMaskIntoConstraints = false
                 pieChartView.isUserInteractionEnabled = false
-                pieChartView.chartDescription?.text = nil
+                pieChartView.chartDescription.text = ""
                 pieChartView.drawHoleEnabled = false
                 pieChartView.legend.enabled = false
                 pieChartView.rotationEnabled = false


### PR DESCRIPTION
<!-- TITLE OF THE PR: For the title, if there is an associated task/todo/pitch, please create the PR with the task name. Example: [iOS] Empty view behaviour -->

### Task

<!-- Please, add here links to the task/pitch/todo/thread that triggered this Pull Request. Example: [[iOS] Empty view behaviour](https://3.basecamp.com/5245563/buckets/26145695/todos/4882286741) -->

Fix compatibility with Xcode 14

### Feature/Issue

<!-- Please describe in short terms what is the scope of the feature or what is the bug that is being fixed -->

Pod dependency `Charts` couldn't build with Xcode 14

### Implementation

<!-- Please describe the general idea of what was implemented. Comments that may help your peer reviewer. Things like: architectural details, points of attention, etc. -->

Updated `Charts` dependency to version `4.1.0` which includes fixes for building with Xcode 14.
Code was updated according to changed interfaces.

### Notes

<!-- If there is any test step, or consideration about the feature, please, add it here. This may include prints/videos of the feature in action. -->